### PR TITLE
fixed tab completion for undo and redo commands

### DIFF
--- a/jambl/src/main/java/jambl/Controller/Commands/DoCommand.java
+++ b/jambl/src/main/java/jambl/Controller/Commands/DoCommand.java
@@ -1,19 +1,36 @@
 package jambl.Controller.Commands;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+
 import jambl.Controller.History;
 import jambl.Controller.Load;
 import jambl.Controller.Memento;
 import jambl.Model.Model;
+import jambl.Model.Parameter;
+import jambl.Model.Class;
+import jambl.Model.Field;
+import jambl.Model.Method;
+import jambl.View.*;
 
 public class DoCommand implements Command2 {
 
     History history;
     Model model;
+    View view;
+    ArrayList<String> tabClasses = new ArrayList<String>();
+    ArrayList<String> tabMethods = new ArrayList<String>();
+    ArrayList<String> tabFields = new ArrayList<String>();
+    ArrayList<String> tabParams = new ArrayList<String>();
+    ArrayList<String> tabTypes = new ArrayList<String>();
+
 
     
-    public DoCommand(History hist, Model mod){
+    public DoCommand(History hist, Model mod, View v){
         history = hist;
         model = mod;
+        view = v;
+
 
     }
 
@@ -25,6 +42,9 @@ public class DoCommand implements Command2 {
             Load newState = new Load(); //new loading object to load the redo state
             newState.loadClasses(redo.getState()); //loads that classes of the redo state
             this.model = newState.loadRelationships(redo.getState()); //loads the relationships of the redo state
+
+            // updates tab completion
+            updateTabs();
         }
 
     }
@@ -37,12 +57,55 @@ public class DoCommand implements Command2 {
                     Load newState = new Load(); // new loading object to load the undo state
                     newState.loadClasses(undo.getState()); //loads the classes of the undo state
                     this.model = newState.loadRelationships(undo.getState()); //loads the relationships of the undo state and
+
+                    // updates tab completion
+                    updateTabs();
                 }
 
     }
 
     public Model getModel(){
         return this.model;
+    }
+
+    public void updateTabs(){
+        HashSet<Class> classes = this.model.getClasses();
+        String type;
+        for(Class aClass : classes){
+            tabClasses.add(aClass.getClassName());
+            HashSet<Field> fields = aClass.getFields();
+            HashSet<Method> methods = aClass.getMethods();
+
+            for(Field aField : fields){
+                tabFields.add(aField.getFieldName());
+                type = aField.getFieldType();
+                if(!tabTypes.contains(type)){
+                    tabTypes.add(type);
+                }
+            }
+
+            for(Method aMethod : methods){
+                tabMethods.add(aMethod.getMethodName());
+                type = aMethod.getReturnType();
+                if(!tabTypes.contains(type)){
+                    tabTypes.add(type);
+                }
+
+                HashSet<Parameter> params = aMethod.getParameters();
+                for(Parameter aParam : params){
+                    tabParams.add(aParam.getParamName());
+                    type = aParam.getParamType();
+                    if(!tabTypes.contains(type)){
+                        tabTypes.add(type);
+                    }
+
+
+                }
+
+            }
+        }
+
+        view.setArrays(tabClasses, tabFields, tabMethods, tabParams, tabTypes);
     }
 
 

--- a/jambl/src/main/java/jambl/Controller/Controller.java
+++ b/jambl/src/main/java/jambl/Controller/Controller.java
@@ -265,14 +265,14 @@ public class Controller {
             
             case REDO:
 
-                DoCommand redo = new DoCommand(history, model);
+                DoCommand redo = new DoCommand(history, model, view);
                 redo.execute();
                 this.model = redo.getModel();
                 break;
             
             case UNDO:
 
-                DoCommand undo = new DoCommand(history, model);
+                DoCommand undo = new DoCommand(history, model, view);
                 undo.unexecute();
                 this.model = undo.getModel();
                 break;


### PR DESCRIPTION
I added a method in doCommand file to iterate through the model and update the various tab completion arrayLists so that when someone undos or redos the correct tabs are available. Also made doCommands take in a view so that the new arraylists can be updated in the view.